### PR TITLE
[update] cheerボタン押下で送金先アドレスをコンテンツコントラクトから取得する

### DIFF
--- a/packages/frontend/components/LearnCanvas/index.tsx
+++ b/packages/frontend/components/LearnCanvas/index.tsx
@@ -89,7 +89,7 @@ const LearnCanvas = () => {
                                         &nbsp;
                                         <Button 
                                             name="Cheer" 
-                                            onClick={() => cheer()}
+                                            onClick={() => cheer(contentFlg)}
                                         />
                                     </div>
                                 </div>


### PR DESCRIPTION
・cheerボタン押下時、送金先のウォレットアドレスを、コンテンツコントラクトから取得するよう変更しました。
・以下のメソッドを追加しました
　getContentInfo: 指定したidに対応したコンテンツ情報を取得する
    ConvertContentFlgToContentId: ContentFlgを、対応するContentIdに変換する。MVP向けの暫定メソッド。